### PR TITLE
quitar .env para despliegue en aws

### DIFF
--- a/Dockerfile.chat
+++ b/Dockerfile.chat
@@ -25,7 +25,7 @@ WORKDIR /app
 COPY --from=builder /app/chat/target/*.jar chat.jar
 
 # Copiar el archivo .env al contenedor
-COPY .env /app/.env
+#COPY .env /app/.env
 
 
 # Exponer los puertos necesarios

--- a/Dockerfile.core
+++ b/Dockerfile.core
@@ -25,7 +25,7 @@ WORKDIR /app
 COPY --from=builder /app/core/target/*.jar core.jar
 
 # Copiar el archivo .env al contenedor
-COPY .env /app/.env
+#COPY .env /app/.env
 
 
 # Exponer los puertos necesarios

--- a/Dockerfile.eureka
+++ b/Dockerfile.eureka
@@ -25,7 +25,7 @@ WORKDIR /app
 COPY --from=builder /app/eureka/target/*.jar eureka.jar
 
 # Copiar el archivo .env al contenedor
-COPY .env /app/.env
+#COPY .env /app/.env
 
 
 # Exponer los puertos necesarios

--- a/Dockerfile.gateway
+++ b/Dockerfile.gateway
@@ -25,7 +25,7 @@ WORKDIR /app
 COPY --from=builder /app/gateway/target/*.jar gateway.jar
 
 # Copiar el archivo .env al contenedor
-COPY .env /app/.env
+#COPY .env /app/.env
 
 
 # Exponer los puertos necesarios


### PR DESCRIPTION
esto se hace para poder hacer el despliegue en aws
si se desea hacerlo en local,es necesario descomentar la linea .env